### PR TITLE
Update generations.js

### DIFF
--- a/config/generations.js
+++ b/config/generations.js
@@ -3,8 +3,9 @@ module.exports = Object.freeze([
   { region: 'Johto', start: 152, end: 251 },
   { region: 'Hoenn', start: 252, end: 386 },
   { region: 'Sinnoh', start: 387, end: 493 },
-  { region: 'Unova', start: 494, end: 648 },
-  { region: 'Kalos', start: 649, end: 721 },
+  { region: 'Unova', start: 494, end: 649 },
+  { region: 'Kalos', start: 650, end: 721 },
   { region: 'Alola', start: 722, end: 807 },
-  { region: 'Unknown', start: 808, end: 809 }
+  { region: 'Unknown', start: 808, end: 809 },
+  {region: 'Galar', start: 810, end: 890 }
 ])


### PR DESCRIPTION
JTAtomico's Photodex generation dividers, with a fixed distinction between Unova and Kalos (and Galar added up to Eternatus).